### PR TITLE
Fix: getAdSet response have a data object instead of array

### DIFF
--- a/docs/Model/ResponseReadAdSet.md
+++ b/docs/Model/ResponseReadAdSet.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**data** | [**\Criteo\Marketing\Model\ReadModelReadAdSet[]**](ReadModelReadAdSet.md) |  | [optional] 
+**data** | [**\Criteo\Marketing\Model\ReadModelReadAdSet**](ReadModelReadAdSet.md) |  | [optional] 
 **warnings** | [**\Criteo\Marketing\Model\ProblemDetails[]**](ProblemDetails.md) |  | [optional] 
 **errors** | [**\Criteo\Marketing\Model\ProblemDetails[]**](ProblemDetails.md) |  | [optional] 
 

--- a/lib/Model/ResponseReadAdSet.php
+++ b/lib/Model/ResponseReadAdSet.php
@@ -58,7 +58,7 @@ class ResponseReadAdSet implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $openAPITypes = [
-        'data' => '\Criteo\Marketing\Model\ReadModelReadAdSet[]',
+        'data' => '\Criteo\Marketing\Model\ReadModelReadAdSet',
         'warnings' => '\Criteo\Marketing\Model\ProblemDetails[]',
         'errors' => '\Criteo\Marketing\Model\ProblemDetails[]'
     ];
@@ -220,7 +220,7 @@ class ResponseReadAdSet implements ModelInterface, ArrayAccess
     /**
      * Gets data
      *
-     * @return \Criteo\Marketing\Model\ReadModelReadAdSet[]|null
+     * @return \Criteo\Marketing\Model\ReadModelReadAdSet|null
      */
     public function getData()
     {
@@ -230,7 +230,7 @@ class ResponseReadAdSet implements ModelInterface, ArrayAccess
     /**
      * Sets data
      *
-     * @param \Criteo\Marketing\Model\ReadModelReadAdSet[]|null $data data
+     * @param \Criteo\Marketing\Model\ReadModelReadAdSet|null $data data
      *
      * @return $this
      */


### PR DESCRIPTION
The ResponseReadAdSet model wasn't properly created and should have the data attribute to be an object instead of an array.